### PR TITLE
Fill out repository field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "ember server",
     "test": "ember try:testall"
   },
-  "repository": "",
+  "repository": "https://github.com/AlexeiDrake/ember-qrcode",
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
This makes it so that npmjs.org shows a link to the repo from https://www.npmjs.com/package/ember-qrcode.